### PR TITLE
LINE Botのタイムアウトを常に1台のマシンが起動するように設定変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ primary_region = "nrt"
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
 [[vm]]


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/ai-counselor/issues/11

# この PR で対応する範囲 / この PR で対応しない範囲

LINEBot回避の為に常に1台のマシンが起動するように変更する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

タイムアウトを回避する為に min_machines_running を 1 に設定、これでタイムアウトが起きる確率はかなり減ると思われる。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし