### PR TITLE
DB用のコンテナを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM python:3.11.3-slim AS build
+
+RUN apt-get update && apt-get install -y ca-certificates
+
 FROM python:3.12.0-slim
 
 WORKDIR /src
@@ -13,5 +17,9 @@ RUN sed '/-e/d' requirements.lock > requirements.txt && \
 COPY ./src/ .
 
 EXPOSE 5000
+
+ENV SSL_CERT_PATH /etc/ssl/certs/ca-certificates.crt
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       BASIC_AUTH_PASSWORD: ${BASIC_AUTH_PASSWORD}
       LINE_CHANNEL_SECRET: ${LINE_CHANNEL_SECRET}
       LINE_CHANNEL_ACCESS_TOKEN: ${LINE_CHANNEL_ACCESS_TOKEN}
+    depends_on:
+      - ai-counselor-mysql
     volumes:
       - ./.flake8:/.flake8
       - ./Makefile:/Makefile
@@ -19,3 +21,21 @@ services:
       - ./src:/src
       - ./tests:/tests
     command: uvicorn main:app --reload --host 0.0.0.0 --port 5000
+  ai-counselor-mysql:
+    build:
+      context: .
+      dockerfile: docker/mysql/Dockerfile
+    platform: linux/amd64
+    environment:
+      MYSQL_DATABASE: ai_counselor_test
+      MYSQL_USER: ai_counselor_test
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      TZ: UTC
+    ports:
+      - "33066:3306"
+    volumes:
+      - ai-counselor-test-data-store:/var/lib/mysql
+      - ./docker/mysql:/docker-entrypoint-initdb.d
+volumes:
+  ai-counselor-test-data-store:

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:8.0.34
+
+COPY ./docker/mysql/config/my.cnf /etc/mysql/conf.d/my.cnf

--- a/docker/mysql/config/my.cnf
+++ b/docker/mysql/config/my.cnf
@@ -1,0 +1,27 @@
+[mysqld]
+character-set-server=utf8mb4
+
+# デフォルト認証プラグイン
+default-authentication-plugin=mysql_native_password
+
+# タイムゾーン
+default-time-zone = UTC
+log_timestamps = UTC
+
+# クエリログ
+general_log = 1
+
+# スロークエリログ
+slow_query_log = 1
+long_query_time = 0.1
+
+default_password_lifetime = 0
+
+[mysql]
+default-character-set = utf8mb4
+
+[client]
+default-character-set=utf8mb4
+
+[mysqldump]
+default-character-set = utf8mb4


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/ai-counselor/issues/12

# この PR で対応する範囲 / この PR で対応しない範囲

DB用のコンテナを利用出来る状態にする。

それ以外の対応は別PRで実施する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

タイトルの通り。DB用のコンテナを追加。

DBはPlanetScaleと互換性の高いMySQL8.0.34のバージョンを利用している。

PlanetScaleはTSL接続が必須なのでアプリ内のコンテナに証明書の追加も実施している。

次回以降のPRで実際にデータベースを使った開発を進めていく。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし