### PR TITLE
メッセージの生成時に過去の会話履歴を含めてLLMに渡すように変更

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "aiomysql>=0.2.0",
     "asyncio>=3.4.3",
     "pytest-asyncio>=0.23.3",
+    "tiktoken>=0.5.2",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -47,10 +47,12 @@ pymysql==1.1.0
 pytest==7.4.4
 pytest-asyncio==0.23.3
 python-dateutil==2.8.2
+regex==2023.12.25
 requests==2.31.0
 six==1.16.0
 sniffio==1.3.0
 starlette==0.32.0.post1
+tiktoken==0.5.2
 tqdm==4.66.1
 typing-extensions==4.9.0
 urllib3==2.1.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -47,10 +47,12 @@ pymysql==1.1.0
 pytest==7.4.4
 pytest-asyncio==0.23.3
 python-dateutil==2.8.2
+regex==2023.12.25
 requests==2.31.0
 six==1.16.0
 sniffio==1.3.0
 starlette==0.32.0.post1
+tiktoken==0.5.2
 tqdm==4.66.1
 typing-extensions==4.9.0
 urllib3==2.1.0

--- a/src/domain/message.py
+++ b/src/domain/message.py
@@ -1,2 +1,14 @@
+from typing import Literal, TypedDict
+
+
 def is_message(value: str) -> bool:
     return 2 <= len(value) <= 5000
+
+
+def get_max_token_limit() -> int:
+    return 10000
+
+
+class ChatMessage(TypedDict):
+    role: Literal["system", "user", "assistant"]
+    content: str

--- a/src/domain/repository/conversation_history_repository_interface.py
+++ b/src/domain/repository/conversation_history_repository_interface.py
@@ -1,4 +1,10 @@
-from typing import TypedDict, Protocol
+from typing import TypedDict, Protocol, List
+from domain.message import ChatMessage
+
+
+class CreateMessagesWithConversationHistoryDto(TypedDict):
+    user_id: str
+    request_message: str
 
 
 class SaveConversationHistoryDto(TypedDict):
@@ -8,5 +14,10 @@ class SaveConversationHistoryDto(TypedDict):
 
 
 class ConversationHistoryRepositoryInterface(Protocol):
+    async def create_messages_with_conversation_history(
+        self, dto: CreateMessagesWithConversationHistoryDto
+    ) -> List[ChatMessage]:
+        ...
+
     async def save_conversation_history(self, dto: SaveConversationHistoryDto) -> None:
         ...

--- a/src/domain/repository/generate_message_repository_interface.py
+++ b/src/domain/repository/generate_message_repository_interface.py
@@ -1,9 +1,10 @@
-from typing import Protocol, TypedDict
+from typing import Protocol, TypedDict, List
+from domain.message import ChatMessage
 
 
 class GenerateMessageRepositoryDto(TypedDict):
     user_id: str
-    message: str
+    chat_messages: List[ChatMessage]
 
 
 class GenerateMessageResult(TypedDict):

--- a/src/infrastructure/openai.py
+++ b/src/infrastructure/openai.py
@@ -1,0 +1,17 @@
+from typing import Literal
+import tiktoken
+
+
+def calculate_token_count(text: str, model: Literal["gpt-4", "gpt-3.5-turbo"]) -> int:
+    tiktoken_encoding = tiktoken.encoding_for_model(model)
+    encoded = tiktoken_encoding.encode(text)
+    return len(encoded)
+
+
+DEFAULT_MAX_TOKEN_LIMIT = 1000
+
+
+def is_token_limit_exceeded(
+    use_token: int, max_token_limit: int = DEFAULT_MAX_TOKEN_LIMIT
+) -> bool:
+    return use_token > max_token_limit

--- a/src/infrastructure/repository/aiomysql/aiomysql_conversation_history_repository.py
+++ b/src/infrastructure/repository/aiomysql/aiomysql_conversation_history_repository.py
@@ -1,6 +1,6 @@
 from typing import cast, List, Literal
 import aiomysql
-from domain.message import ChatMessage
+from domain.message import ChatMessage, get_max_token_limit
 from domain.prompt import create_prompt
 from domain.repository.conversation_history_repository_interface import (
     SaveConversationHistoryDto,
@@ -11,7 +11,11 @@ from infrastructure.openai import calculate_token_count, is_token_limit_exceeded
 
 
 class AiomysqlConversationHistoryRepository(ConversationHistoryRepositoryInterface):
-    def __init__(self, connection: aiomysql.Connection, max_token_limit: int) -> None:
+    def __init__(
+        self,
+        connection: aiomysql.Connection,
+        max_token_limit: int = get_max_token_limit(),
+    ) -> None:
         self.connection = connection
         self.max_token_limit = max_token_limit
 

--- a/src/infrastructure/repository/aiomysql/aiomysql_conversation_history_repository.py
+++ b/src/infrastructure/repository/aiomysql/aiomysql_conversation_history_repository.py
@@ -1,13 +1,74 @@
+from typing import cast, List, Literal
 import aiomysql
+from domain.message import ChatMessage
+from domain.prompt import create_prompt
 from domain.repository.conversation_history_repository_interface import (
     SaveConversationHistoryDto,
+    CreateMessagesWithConversationHistoryDto,
     ConversationHistoryRepositoryInterface,
 )
+from infrastructure.openai import calculate_token_count, is_token_limit_exceeded
 
 
 class AiomysqlConversationHistoryRepository(ConversationHistoryRepositoryInterface):
-    def __init__(self, connection: aiomysql.Connection) -> None:
+    def __init__(self, connection: aiomysql.Connection, max_token_limit: int) -> None:
         self.connection = connection
+        self.max_token_limit = max_token_limit
+
+    async def create_messages_with_conversation_history(
+        self, dto: CreateMessagesWithConversationHistoryDto
+    ) -> List[ChatMessage]:
+        async with self.connection.cursor() as cursor:
+            sql = """
+            SELECT user_message, ai_message
+            FROM conversation_histories
+            WHERE user_id = %s
+            ORDER BY id DESC
+            LIMIT 10
+            """
+            await cursor.execute(sql, (dto["user_id"],))
+            result = await cursor.fetchall()
+            if result:
+                result.reverse()
+
+            conversation_history = [
+                {"role": role_type, "content": row[message_type]}
+                for row in result
+                for role_type, message_type in [
+                    ("user", "user_message"),
+                    ("assistant", "ai_message"),
+                ]
+            ]
+
+        # もし会話履歴がまだ存在しなければ、システムメッセージを追加
+        if not conversation_history:
+            conversation_history.append({"role": "system", "content": create_prompt()})
+
+        # 新しいメッセージを会話履歴に追加
+        conversation_history.append({"role": "user", "content": dto["request_message"]})
+
+        # 実際に会話履歴に含めるメッセージ
+        chat_messages: List[ChatMessage] = []
+        total_tokens = 0
+
+        for message in reversed(conversation_history):
+            message_tokens = calculate_token_count(message["content"], "gpt-4")
+            if (
+                is_token_limit_exceeded(
+                    total_tokens + message_tokens, self.max_token_limit
+                )
+                and chat_messages
+            ):
+                # トークン数が最大を超える場合、ループを抜ける
+                break
+            role = cast(Literal["system", "user", "assistant"], message["role"])
+            chat_messages.insert(0, ChatMessage(role=role, content=message["content"]))
+            total_tokens += message_tokens
+
+        if not any(message["role"] == "system" for message in chat_messages):
+            chat_messages.insert(0, {"role": "system", "content": create_prompt()})
+
+        return chat_messages
 
     async def save_conversation_history(self, dto: SaveConversationHistoryDto) -> None:
         async with self.connection.cursor() as cursor:

--- a/src/infrastructure/repository/openai/openai_generate_message_repository.py
+++ b/src/infrastructure/repository/openai/openai_generate_message_repository.py
@@ -1,11 +1,12 @@
 import os
+from typing import cast, List
 from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionMessageParam
 from domain.repository.generate_message_repository_interface import (
     GenerateMessageRepositoryInterface,
     GenerateMessageRepositoryDto,
     GenerateMessageResult,
 )
-from domain.prompt import create_prompt
 
 
 class OpenAiGenerateMessageRepository(GenerateMessageRepositoryInterface):
@@ -16,17 +17,12 @@ class OpenAiGenerateMessageRepository(GenerateMessageRepositoryInterface):
     async def generate_message(
         self, dto: GenerateMessageRepositoryDto
     ) -> GenerateMessageResult:
+        messages = cast(List[ChatCompletionMessageParam], dto.get("chat_messages"))
         user_id = str(dto.get("user_id"))
 
         response = await self.client.chat.completions.create(
             model="gpt-4-1106-preview",
-            messages=[
-                {"role": "system", "content": create_prompt()},
-                {
-                    "role": "user",
-                    "content": dto.get("message"),
-                },
-            ],
+            messages=messages,
             temperature=0.7,
             user=user_id,
         )

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,6 @@ from usecase.generate_message_use_case import (
     GenerateMessageUseCase,
 )
 from log.logger import AppLogger, ErrorLogExtra
-from domain.message import get_max_token_limit
 
 app = FastAPI(
     title="ai-counselor",
@@ -158,7 +157,6 @@ async def handle_callback(request: Request):
                     conversation_history_repository = (
                         AiomysqlConversationHistoryRepository(
                             connection,
-                            get_max_token_limit(),
                         )
                     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ from usecase.generate_message_use_case import (
     GenerateMessageUseCase,
 )
 from log.logger import AppLogger, ErrorLogExtra
+from domain.message import get_max_token_limit
 
 app = FastAPI(
     title="ai-counselor",
@@ -155,7 +156,10 @@ async def handle_callback(request: Request):
                     generate_message_repository = OpenAiGenerateMessageRepository()
 
                     conversation_history_repository = (
-                        AiomysqlConversationHistoryRepository(connection)
+                        AiomysqlConversationHistoryRepository(
+                            connection,
+                            get_max_token_limit(),
+                        )
                     )
 
                     dto = GenerateMessageUseCaseDto(

--- a/src/presentation/controller/generate_message_controller.py
+++ b/src/presentation/controller/generate_message_controller.py
@@ -3,7 +3,7 @@ from starlette.requests import Request
 from pydantic import BaseModel, field_validator, Field
 from http import HTTPStatus
 from domain.user_id import is_user_id
-from domain.message import is_message
+from domain.message import is_message, get_max_token_limit
 from log.logger import AppLogger, ErrorLogExtra
 from usecase.generate_message_use_case import (
     GenerateMessageUseCase,
@@ -84,7 +84,8 @@ class GenerateMessageController:
             generate_message_repository = OpenAiGenerateMessageRepository()
 
             conversation_history_repository = AiomysqlConversationHistoryRepository(
-                connection
+                connection,
+                get_max_token_limit(),
             )
 
             use_case = GenerateMessageUseCase(

--- a/src/presentation/controller/generate_message_controller.py
+++ b/src/presentation/controller/generate_message_controller.py
@@ -3,7 +3,7 @@ from starlette.requests import Request
 from pydantic import BaseModel, field_validator, Field
 from http import HTTPStatus
 from domain.user_id import is_user_id
-from domain.message import is_message, get_max_token_limit
+from domain.message import is_message
 from log.logger import AppLogger, ErrorLogExtra
 from usecase.generate_message_use_case import (
     GenerateMessageUseCase,
@@ -85,7 +85,6 @@ class GenerateMessageController:
 
             conversation_history_repository = AiomysqlConversationHistoryRepository(
                 connection,
-                get_max_token_limit(),
             )
 
             use_case = GenerateMessageUseCase(

--- a/src/usecase/generate_message_use_case.py
+++ b/src/usecase/generate_message_use_case.py
@@ -35,12 +35,21 @@ class GenerateMessageUseCase:
     ) -> GenerateMessageUseCaseResult:
         user_id: str = self.dto["user_id"]
 
-        generate_message_repository_dto = GenerateMessageRepositoryDto(
-            user_id=user_id,
-            message=self.dto["message"],
-        )
-
         try:
+            chat_messages = await self.dto[
+                "conversation_history_repository"
+            ].create_messages_with_conversation_history(
+                {
+                    "user_id": user_id,
+                    "request_message": self.dto["message"],
+                }
+            )
+
+            generate_message_repository_dto = GenerateMessageRepositoryDto(
+                user_id=user_id,
+                chat_messages=chat_messages,
+            )
+
             generate_message_result = await self.dto[
                 "generate_message_repository"
             ].generate_message(generate_message_repository_dto)

--- a/tests/infrastructure/repository/aiomysql/aiomysql_conversation_history_repository/test_create_messages_with_conversation_history.py
+++ b/tests/infrastructure/repository/aiomysql/aiomysql_conversation_history_repository/test_create_messages_with_conversation_history.py
@@ -1,0 +1,130 @@
+import pytest
+from typing import Tuple
+from aiomysql import Connection
+from tests.db.create_and_setup_db_connection import create_and_setup_db_connection
+from infrastructure.repository.aiomysql.aiomysql_conversation_history_repository import (
+    AiomysqlConversationHistoryRepository,
+    CreateMessagesWithConversationHistoryDto,
+)
+from domain.prompt import create_prompt
+
+
+@pytest.fixture
+async def create_test_db_connection() -> Tuple[Connection, str]:
+    connection, test_db_name = await create_and_setup_db_connection()
+
+    async with connection.cursor() as cursor:
+        await cursor.execute("TRUNCATE TABLE conversation_histories")
+
+        await cursor.executemany(
+            """
+            INSERT INTO
+              conversation_histories
+              (user_id, user_message, ai_message)
+            VALUES
+              (%s, %s, %s)
+            """,
+            [
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗1",
+                    "もちろんです。何でもお話ください❗1",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗2",
+                    "もちろんです。何でもお話ください❗2",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗3",
+                    "もちろんです。何でもお話ください❗3",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗4",
+                    "もちろんです。何でもお話ください❗4",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗5",
+                    "もちろんです。何でもお話ください❗5",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗6",
+                    "もちろんです。何でもお話ください❗6",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗7",
+                    "もちろんです。何でもお話ください❗7",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗8",
+                    "もちろんです。何でもお話ください❗8",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗9",
+                    "もちろんです。何でもお話ください❗9",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗10",
+                    "もちろんです。何でもお話ください❗10",
+                ),
+                (
+                    "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001",
+                    "こんにちは、私の悩みを聞いてください❗11",
+                    "もちろんです。何でもお話ください❗11",
+                ),
+            ],
+        )
+    await connection.commit()
+
+    return connection, test_db_name
+
+
+@pytest.mark.asyncio
+async def test_create_messages_with_conversation_history(create_test_db_connection):
+    connection, test_db_name = await create_test_db_connection
+
+    user_id = "Uaxxxxxxxxxxxxxxxxxxxxxxxxxxx0001"
+
+    dto = CreateMessagesWithConversationHistoryDto(
+        user_id=user_id,
+        request_message="おはようございます。私の相談相手になって欲しいです。",
+    )
+
+    repository = AiomysqlConversationHistoryRepository(connection, 1000)
+
+    chat_messages = await repository.create_messages_with_conversation_history(dto)
+
+    expected = [
+        {"role": "system", "content": create_prompt()},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗2"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗2"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗3"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗3"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗4"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗4"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗5"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗5"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗6"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗6"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗7"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗7"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗8"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗8"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗9"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗9"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗10"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗10"},
+        {"role": "user", "content": "こんにちは、私の悩みを聞いてください❗11"},
+        {"role": "assistant", "content": "もちろんです。何でもお話ください❗11"},
+        {"role": "user", "content": "おはようございます。私の相談相手になって欲しいです。"},
+    ]
+
+    assert expected == chat_messages


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/ai-counselor/issues/12

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/keitakn/ai-counselor/issues/12 の完了の定義を満たす為にレスポンス生成時に過去の会話履歴を含めてLLMに渡すように変更する。

このPRで https://github.com/keitakn/ai-counselor/issues/12 の完了の定義は満たされる。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

保存されている会話履歴を元にLLMに会話履歴を渡して前回の会話内容を踏まえた上での回答を生成するようにしました。

会話履歴周りのロジックのテストに関しては `infrastructure/repository/aiomysql/aiomysql_conversation_history_repository/test_create_messages_with_conversation_history.py` のテストコードが担っているいます。

過去の会話履歴はトークン数の合計が10000になるまで追加しています。この数字は運用しながら調整を実施します。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし